### PR TITLE
Fix/rate limit error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     classifiers=["Programming Language :: Python :: 3 :: Only"],
     py_modules=["tap_duedil"],
     install_requires=[
-        "singer-python==5.0.4",
+        "singer-python==5.4.1",
         "requests",
     ],
     entry_points="""

--- a/tap_duedil/http.py
+++ b/tap_duedil/http.py
@@ -14,6 +14,10 @@ class RateLimitException(Exception):
     pass
 
 
+class UnhandledAPIErrorException(Exception):
+    pass
+
+
 def _join(a, b):
     return a.rstrip("/") + "/" + b.lstrip("/")
 
@@ -57,15 +61,21 @@ class Client(object):
         return requests.Request(method="POST", url=self.url(path), data=body, params=query, **kwargs)
 
     @backoff.on_exception(backoff.expo,
+                          UnhandledAPIErrorException,
+                          max_tries=8)
+    @backoff.on_exception(backoff.expo,
                           RateLimitException,
-                          max_tries=5,
-                          factor=2)
+                          max_tries=8)
     def request_with_handling(self, request, tap_stream_id):
         with metrics.http_request_timer(tap_stream_id) as timer:
             response = self.prepare_and_send(request)
             timer.tags[metrics.Tag.http_status_code] = response.status_code
-        if response.status_code in [429, 503, 500]:
+        if response.status_code in [429]:
+            LOGGER.info("Received rate limit error (code={})".format(response.status_code))
             raise RateLimitException()
+        if response.status_code in [500, 503]:
+            LOGGER.info("Received unexpected error (code={})".format(response.status_code))
+            raise UnhandledAPIErrorException()
         if response.status_code == 404:
             return None
         if response.status_code == 400:
@@ -77,18 +87,32 @@ class Client(object):
         response.raise_for_status()
         return response.json()
 
+
     def GET(self, request_kwargs, *args, **kwargs):
-        req = self.create_get_request(**request_kwargs)
         try:
+            req = self.create_get_request(**request_kwargs)
             return self.request_with_handling(req, *args, **kwargs)
+        except RateLimitException as e:
+            LOGGER.info("Encountered rate limit exception. Returning None")
+            return None
+        except UnhandledAPIErrorException as e:
+            LOGGER.info("Encountered unhandled API error. Returning None")
+            return None
         except Exception as e:
             LOGGER.error(e)
-            LOGGER.info("Unhandled exception - Trying again")
+            LOGGER.info("Unhandled exception")
+            return None
 
-            self.unhandled_500s += 1
-            if self.unhandled_500s > MAX_ERROR:
-                raise
 
     def POST(self, request_kwargs, *args, **kwargs):
-        req = self.create_post_request(**request_kwargs)
-        return self.request_with_handling(req, *args, **kwargs)
+        try:
+            req = self.create_post_request(**request_kwargs)
+            return self.request_with_handling(req, *args, **kwargs)
+        except RateLimitException as e:
+            return None
+        except UnhandledAPIErrorException as e:
+            return None
+        except Exception as e:
+            LOGGER.error(e)
+            LOGGER.info("Unhandled exception")
+            return None

--- a/tap_duedil/http.py
+++ b/tap_duedil/http.py
@@ -80,9 +80,6 @@ class Client(object):
             return None
         if response.status_code == 400:
             LOGGER.fatal(response.json())
-        if tap_stream_id == 'company_query' and response.status_code == 500:
-            LOGGER.info('POSSIBLE CACHE MISS - RECEIVED 500 ERROR. Retrying!')
-            raise RateLimitException()
 
         response.raise_for_status()
         return response.json()

--- a/tap_duedil/http.py
+++ b/tap_duedil/http.py
@@ -56,8 +56,8 @@ class Client(object):
 
     def create_post_request(self, path, **kwargs):
         data = kwargs.pop('data', {})
-        query = data.pop('query', {})
-        body = json.dumps(data.pop('body', {}))
+        query = data.get('query', {})
+        body = json.dumps(data.get('body', {}))
         return requests.Request(method="POST", url=self.url(path), data=body, params=query, **kwargs)
 
     @backoff.on_exception(backoff.expo,

--- a/tap_duedil/streams.py
+++ b/tap_duedil/streams.py
@@ -58,7 +58,15 @@ class CompanyQuery(Stream):
             params = self.get_params(ctx, offset, query)
             data = {"path": self.path, "data": params}
             resp = ctx.client.POST(data, self.tap_stream_id)
-            resp_companies = resp.pop('companies')
+            if resp is None:
+                LOGGER.info("Unable to get results for stream={}, data={}".format(self.tap_stream_id, data))
+                # what else can we do here? If we get None back, it's because the API
+                # was unable to produce a successful response for this query. For now,
+                # just move onto the next offset
+                offset += 50
+                continue
+            else:
+                resp_companies = resp.pop('companies')
 
             companies = [transform(company, schema) for company in resp_companies]
             self.write_records(companies)

--- a/tap_duedil/streams.py
+++ b/tap_duedil/streams.py
@@ -1,6 +1,7 @@
 import singer
 from singer import metrics, transform
 import datetime
+import time
 
 LOGGER = singer.get_logger()
 
@@ -48,6 +49,25 @@ class CompanyQuery(Stream):
             "body": query
         }
 
+    def _company_fetch(self, ctx, offset, query, attempts=0):
+        if attempts > 2:
+            LOGGER.info("Query for stream={} with path={}, query={} failed after retrying - exiting".format(
+                        self.tap_stream_id,
+                        self.path,
+                        query))
+            raise RuntimeError("Failed after retry for company query")
+
+        params = self.get_params(ctx, offset, query)
+        data = {"path": self.path, "data": params}
+        resp = ctx.client.POST(data, self.tap_stream_id)
+
+        if resp is None:
+            LOGGER.info("Unable to get results for stream={}, data={}".format(self.tap_stream_id, data))
+            LOGGER.info("Sleeping for 30 seconds, then trying again")
+            time.sleep(30)
+            return self._company_fetch(ctx, offset, query, attempts + 1)
+        else:
+            return resp
 
     def _sync(self, ctx, query):
         schema = ctx.catalog.get_stream(self.tap_stream_id).schema.to_dict()
@@ -55,18 +75,8 @@ class CompanyQuery(Stream):
         all_companies = []
         offset = 0
         while True:
-            params = self.get_params(ctx, offset, query)
-            data = {"path": self.path, "data": params}
-            resp = ctx.client.POST(data, self.tap_stream_id)
-            if resp is None:
-                LOGGER.info("Unable to get results for stream={}, data={}".format(self.tap_stream_id, data))
-                # what else can we do here? If we get None back, it's because the API
-                # was unable to produce a successful response for this query. For now,
-                # just move onto the next offset
-                offset += 50
-                continue
-            else:
-                resp_companies = resp.pop('companies')
+            resp = self._company_fetch(ctx, offset, query)
+            resp_companies = resp.pop('companies')
 
             companies = [transform(company, schema) for company in resp_companies]
             self.write_records(companies)


### PR DESCRIPTION
- increase timeout for rate limit exceptions, unhandled errors
- on persistent unhandled errors, return None instead of exiting
- make company querying more resilient for unexpected errors